### PR TITLE
Fixes Workflow under Catalina

### DIFF
--- a/src/scripts/libs/Workflows.php
+++ b/src/scripts/libs/Workflows.php
@@ -32,7 +32,7 @@ class Workflows {
     $this->home = exec('printf $HOME');
 
     if (file_exists('info.plist')):
-      $this->bundle = $this->get('bundleid', 'info.plist');
+      $this->bundle = $this->get('bundleid', 'info');
     endif;
 
     if (!is_null($bundleid)):


### PR DESCRIPTION
`defaults read` has changed under Catalina. `plist` extension must be omitted.