### PR TITLE
Update Slack API call to retrieve User data.

### DIFF
--- a/src/scripts/helpers/service/SingleTeamSlackService.php
+++ b/src/scripts/helpers/service/SingleTeamSlackService.php
@@ -110,7 +110,7 @@ class SingleTeamSlackService implements SlackServiceInterface {
   public function getIms($excludeDeleted = false) {
     $ims = Utils::getWorkflows()->read('ims.' . $this->teamId);
     if ($ims === false) {
-      $ims = $this->commander->execute('im.list')->getBody()['ims'];
+      $ims = $this->commander->execute('conversations.list')->getBody()['channels'];
       $auth = $this->getAuth();
       foreach ($ims as $index => $im) {
         $ims[$index] = Utils::extend($im, ['auth' => $auth]);


### PR DESCRIPTION
 The 'im.list' method of the Slack API is deprecated (https://api.slack.com/methods/im.list). The call is replaced with the corresponding call to 'conversations.list'. With the suggested changes, the user functionality works again.