### PR TITLE
Fixed opening IM

### DIFF
--- a/src/scripts/controllers/ChannelController.php
+++ b/src/scripts/controllers/ChannelController.php
@@ -126,12 +126,6 @@ class ChannelController extends SlackController {
 
     $id = $channel->getId();
 
-    // Get the IM id if a user
-    if ($channel instanceof \AlfredSlack\Models\UserModel) {
-      $im = $this->service->getImByUser($channel);
-      $id = $im->getId();
-    }
-
     $url = 'slack://channel?id=' . $id . '&team=' . $channel->getAuth()->getTeamId();
 
     Utils::openUrl($url);


### PR DESCRIPTION
This change should fix a bug where typing "slack @whoever" opened the slack app but didnt navigate to that user. It appears slack now treats both channels and IMs as the same thing