### PR TITLE
Add types parameter when calling `conversations.list` api.

### DIFF
--- a/src/scripts/helpers/service/SingleTeamSlackService.php
+++ b/src/scripts/helpers/service/SingleTeamSlackService.php
@@ -72,7 +72,7 @@ class SingleTeamSlackService implements SlackServiceInterface {
   public function getChannels($excludeArchived = false) {
     $channels = Utils::getWorkflows()->read('channels.' . $this->teamId);
     if ($channels === false) {
-      $params = [];
+      $params['types'] = 'public_channel,private_channel';
       if ($excludeArchived === true) {
         $params['exclude_archived'] = '1';
       }


### PR DESCRIPTION
This change should fix issue #63.
`conversations.list` api gets only public channels is default. I added parameters to get all channels.
This fix works fine on my machine.